### PR TITLE
Fixed SCOPE OAuth REST client Demo

### DIFF
--- a/docs/guides/quick-start/01-introduction.md
+++ b/docs/guides/quick-start/01-introduction.md
@@ -83,7 +83,7 @@ A typical Admin API request, including headers, will look as shown below:
   "body":{
     "client_id": "administration",
     "grant_type": "password",
-    "scopes": "write",
+    "scope": "write",
     "username": "your.username@shopware.com",
     "password": "your.password@123"
 }


### PR DESCRIPTION
Changed the "scopes" paramater to "scope" in the quick-start introduction to match the actual OAuth parameter specified in https://github.com/thephpleague/oauth2-server/blob/master/src/Grant/PasswordGrant.php