### PR TITLE
add/guardrail-for-octo-calls

### DIFF
--- a/.github/workflows/manual_versioning.yml
+++ b/.github/workflows/manual_versioning.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   guard:
     name: "Check version matches branch"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     outputs:
       proceed: ${{ steps.check.outputs.proceed }}
     steps:

--- a/.github/workflows/manual_versioning.yml
+++ b/.github/workflows/manual_versioning.yml
@@ -34,31 +34,63 @@ on:
         default: true
 
 jobs:
+  guard:
+    name: "Check version matches branch"
+    runs-on: ubuntu-24.04
+    outputs:
+      proceed: ${{ steps.check.outputs.proceed }}
+    steps:
+      - id: check
+        env:
+          VERSION: ${{ inputs.shopware_version }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          # Map branch -> expected version pattern. Bump `latest` when it moves.
+          case "$BRANCH" in
+            latest)     expected='^v?6\.7\.' ;;
+            v6.6)       expected='^v?6\.6\.' ;;        
+            main|trunk) expected='.*' ;;
+            *)          expected='.*' ;;
+          esac
+
+          if [[ "$VERSION" =~ $expected ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Accepting $VERSION on branch $BRANCH"
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping: $VERSION does not belong on branch $BRANCH"
+          fi
+
   generate-trunk:
-    if: ${{ inputs.trigger_default_schema }}
+    needs: guard
+    if: ${{ needs.guard.outputs.proceed == 'true' && inputs.trigger_default_schema }}
     uses: ./.github/workflows/base_schema.yml
     with:
       shopware_version: ${{ inputs.shopware_version }}
       php_version: ${{ inputs.php_version }}
     secrets: inherit
-    
+
   generate-commercial-trunk:
-    if: ${{ inputs.trigger_commercial_schema }}
+    needs: guard
+    if: ${{ needs.guard.outputs.proceed == 'true' && inputs.trigger_commercial_schema }}
     uses: ./.github/workflows/plugin_commercial_schema.yml
     with:
       shopware_version: ${{ inputs.shopware_version }}
       php_version: ${{ inputs.php_version }}
     secrets: inherit
-    
+
   generate-digitalsalesroom-trunk:
-    if: ${{ inputs.trigger_digitalsalesroom_schema }}
+    needs: guard
+    if: ${{ needs.guard.outputs.proceed == 'true' && inputs.trigger_digitalsalesroom_schema }}
     uses: ./.github/workflows/plugin_digitalsalesroom_schema.yml
     with:
       shopware_version: ${{ inputs.shopware_version }}
       php_version: ${{ inputs.php_version }}
     secrets: inherit
+
   generate-customproducts-trunk:
-    if: ${{ inputs.trigger_customproducts_schema }}
+    needs: guard
+    if: ${{ needs.guard.outputs.proceed == 'true' && inputs.trigger_customproducts_schema }}
     uses: ./.github/workflows/plugin_customproducts_schema.yml
     with:
       shopware_version: ${{ inputs.shopware_version }}

--- a/.github/workflows/manual_versioning.yml
+++ b/.github/workflows/manual_versioning.yml
@@ -48,7 +48,7 @@ jobs:
           # Map branch -> expected version pattern. Bump `latest` when it moves.
           case "$BRANCH" in
             latest)     expected='^v?6\.7\.' ;;
-            v6.6)       expected='^v?6\.6\.' ;;        
+            v6.6)       expected='^v?6\.6\.' ;;
             main|trunk) expected='.*' ;;
             *)          expected='.*' ;;
           esac


### PR DESCRIPTION
This pull request adds a guard step to the `manual_versioning.yml` GitHub Actions workflow to ensure that the provided Shopware version matches the expected version pattern for the target branch. The workflow jobs for generating schemas will now only run if the guard check passes, preventing version mismatches.

Workflow validation improvements:

* Added a new `guard` job that checks if the `shopware_version` input matches the expected version pattern for the current branch (e.g., `v6.7.x` for `latest`, `v6.6.x` for `v6.6`). The job sets an output (`proceed`) that determines whether subsequent jobs should run.
* Updated all schema generation jobs (`generate-trunk`, `generate-commercial-trunk`, `generate-digitalsalesroom-trunk`, `generate-customproducts-trunk`) to depend on the `guard` job and only proceed if the guard's `proceed` output is `true`, ensuring version consistency across branches.


TLDR: We got PRs on latest from 6.6.x - this stops it.