### PR TITLE
docs: clarify deterministic ID generation for imports

### DIFF
--- a/docs/concepts/endpoint-structure/request-response-structure.md
+++ b/docs/concepts/endpoint-structure/request-response-structure.md
@@ -81,6 +81,12 @@ Refer to the docs for more information on other [response headers](https://devel
 }
 ```
 
+#### Entity IDs
+
+Primary and foreign keys such as `id` and `taxId` are **32-character lowercase hexadecimal strings without hyphens**. This is Shopware's API representation of a 128-bit identifier. It is not the hyphenated RFC 4122 string format that most UUID libraries generate by default.
+
+To derive stable IDs from external keys during imports (for example, using `md5()` or UUID v3/v5), see [Primary Keys](writing-entities/README.md#primary-keys) in the Writing entities guide.
+
 ## Response format
 
 ### Response headers

--- a/docs/concepts/endpoint-structure/writing-entities/README.md
+++ b/docs/concepts/endpoint-structure/writing-entities/README.md
@@ -25,7 +25,7 @@ See the [Entity Reference](../../../resources/entity-reference.md) section of th
 
 ### Primary Keys
 
-Shopware 6 uses 128-bit client-generated identifiers as primary keys instead of auto increments. In API payloads, these appear as **32 lowercase hexadecimal characters without hyphens** (for example, `01bd7e70a50443ec96a01fd34890dcc5`). See the [Request body](../request-response-structure.md#request-body) section for examples.
+Shopware 6 uses 128-bit client-generated identifiers as primary keys instead of auto-increments. In API payloads, these appear as **32 lowercase hexadecimal characters without hyphens** (for example, `01bd7e70a50443ec96a01fd34890dcc5`). See the [Request body](../request-response-structure.md#request-body) section for examples.
 
 This is not the hyphenated string format defined by [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122). Passing UUIDs with hyphens returns a `FRAMEWORK__INVALID_UUID` error. See [shopware/shopware#274](https://github.com/shopware/shopware/issues/274#issuecomment-549374502) for background.
 

--- a/docs/concepts/endpoint-structure/writing-entities/README.md
+++ b/docs/concepts/endpoint-structure/writing-entities/README.md
@@ -6,11 +6,11 @@ A list of all entities available for these operations can be found in the [Entit
 
 **Example:** The entity `customer_group` is available under the endpoint `api/customer-group`. For an entity, the system automatically generates the following routes where the entity can be written
 
-| Name | Method | Route | Usage |
-| :--- | :--- | :--- | :--- |
-| api.customer\_group.update | PATCH | /api/customer-group/{id} | Update the entity with the provided ID |
-| api.customer\_group.delete | DELETE | /api/customer-group/{id} | Delete the entity |
-| api.customer\_group.create | POST | /api/customer-group | Create a new entity |
+| Name                       | Method | Route                    | Usage                                  |
+|:---------------------------|:-------|:-------------------------|:---------------------------------------|
+| api.customer\_group.update | PATCH  | /api/customer-group/{id} | Update the entity with the provided ID |
+| api.customer\_group.delete | DELETE | /api/customer-group/{id} | Delete the entity                      |
+| api.customer\_group.create | POST   | /api/customer-group      | Create a new entity                    |
 
 <!-- theme: warning -->
 > **PATCH** method only adds properties and does not delete old references. To perform both operations, use [Sync API](bulk-payloads.md) endpoints.
@@ -27,13 +27,13 @@ See the [Entity Reference](../../../resources/entity-reference.md) section of th
 
 Shopware 6 uses 128-bit client-generated identifiers as primary keys instead of auto-increments. In API payloads, these appear as **32 lowercase hexadecimal characters without hyphens** (for example, `01bd7e70a50443ec96a01fd34890dcc5`). See the [Request body](../request-response-structure.md#request-body) section for examples.
 
-This is not the hyphenated string format defined by [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122). Passing UUIDs with hyphens returns a `FRAMEWORK__INVALID_UUID` error. See [shopware/shopware#274](https://github.com/shopware/shopware/issues/274#issuecomment-549374502) for background.
+This is not the hyphenated string format defined by [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122). Passing UUIDs with hyphens returns a `FRAMEWORK__INVALID_UUID` error. See [shopware/shopware#274](https://github.com/shopware/shopware/issues/274#issuecomment-549374502) for a background.
 
 We have opted for this approach for the following reasons:
 
 * IDs can be provided (client-generated) when creating an entity
 * Minuscule likelihood of generating ID collisions
-* Data integrations become easier, because existing primary keys can be hashed to generate UUIDs
+* Data integrations become easier because existing primary keys can be hashed to generate UUIDs
 
 Shopware typically generates time-ordered or random UUIDs internally, but the API accepts any valid 32-character hex value — it does not enforce RFC version bits.
 
@@ -55,12 +55,12 @@ $payload[] = [
 
 [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.3) defines name-based UUIDs for exactly this use case:
 
-| Approach | Hash | RFC UUID version | Fits API format directly? |
-| :--- | :--- | :--- | :--- |
-| `md5($name)` | MD5 (full 128 bits as hex) | Similar spirit to v3, but without namespace/version bits | Yes |
-| `Uuid::uuid3($ns, $name)` | MD5 with namespace | UUID v3 | No — strip hyphens |
-| `Uuid::uuid5($ns, $name)` | SHA-1 truncated to 128 bits | UUID v5 | No — strip hyphens |
-| `sha1($name)` | SHA-1 (160 bits) | N/A | **No** — 40 hex characters, too long |
+| Approach                  | Hash                        | RFC UUID version                                         | Fits API format directly?            |
+|:--------------------------|:----------------------------|:---------------------------------------------------------|:-------------------------------------|
+| `md5($name)`              | MD5 (full 128 bits as hex)  | Similar spirit to v3, but without namespace/version bits | Yes                                  |
+| `Uuid::uuid3($ns, $name)` | MD5 with namespace          | UUID v3                                                  | No — strip hyphens                   |
+| `Uuid::uuid5($ns, $name)` | SHA-1 truncated to 128 bits | UUID v5                                                  | No — strip hyphens                   |
+| `sha1($name)`             | SHA-1 (160 bits)            | N/A                                                      | **No** — 40 hex characters, too long |
 
 Using a UUID library makes the intent explicit and lets you scope IDs with a namespace:
 

--- a/docs/concepts/endpoint-structure/writing-entities/README.md
+++ b/docs/concepts/endpoint-structure/writing-entities/README.md
@@ -25,19 +25,61 @@ See the [Entity Reference](../../../resources/entity-reference.md) section of th
 
 ### Primary Keys
 
-Shopware 6 works with UUIDv4 as primary keys instead of auto increments. We have opted for this standard for the following reasons:
+Shopware 6 uses 128-bit client-generated identifiers as primary keys instead of auto increments. In API payloads, these appear as **32 lowercase hexadecimal characters without hyphens** (for example, `01bd7e70a50443ec96a01fd34890dcc5`). See the [Request body](../request-response-structure.md#request-body) section for examples.
 
-* IDs can be provided \(client-generated\) when creating an entity
+This is not the hyphenated string format defined by [RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122). Passing UUIDs with hyphens returns a `FRAMEWORK__INVALID_UUID` error. See [shopware/shopware#274](https://github.com/shopware/shopware/issues/274#issuecomment-549374502) for background.
+
+We have opted for this approach for the following reasons:
+
+* IDs can be provided (client-generated) when creating an entity
 * Minuscule likelihood of generating ID collisions
 * Data integrations become easier, because existing primary keys can be hashed to generate UUIDs
 
-> Shopware doesn't check UUIDs for validity, so if you're creating an import, you can hash a primary key of your record and use it as its Shopware id.
-> ```php
-> $payload[] = [
->   'id' => md5($product->getUniqueIdentifier());
-> ]
-> ```
-> This way, you can later on use that identifier to push instant updates to the changed records. Of course, you can use a similar pattern for related entities.
+Shopware typically generates time-ordered or random UUIDs internally, but the API accepts any valid 32-character hex value — it does not enforce RFC version bits.
+
+#### Deterministic IDs for imports
+
+When importing data from an external system, you often want a stable Shopware ID derived from a key you already have (such as a SKU or legacy primary key). Shopware validates the **format** (32 hex characters) but not RFC version semantics, so deterministic hashes are valid for imports.
+
+**Pragmatic approach: `md5()`**
+
+`md5()` is a simple choice because it produces exactly 32 hexadecimal characters, matching the API format with no conversion:
+
+```php
+$payload[] = [
+    'id' => md5($product->getUniqueIdentifier()),
+];
+```
+
+**Standard-based alternative: UUID v3/v5**
+
+[RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.3) defines name-based UUIDs for exactly this use case:
+
+| Approach | Hash | RFC UUID version | Fits API format directly? |
+| :--- | :--- | :--- | :--- |
+| `md5($name)` | MD5 (full 128 bits as hex) | Similar spirit to v3, but without namespace/version bits | Yes |
+| `Uuid::uuid3($ns, $name)` | MD5 with namespace | UUID v3 | No — strip hyphens |
+| `Uuid::uuid5($ns, $name)` | SHA-1 truncated to 128 bits | UUID v5 | No — strip hyphens |
+| `sha1($name)` | SHA-1 (160 bits) | N/A | **No** — 40 hex characters, too long |
+
+Using a UUID library makes the intent explicit and lets you scope IDs with a namespace:
+
+```php
+use Ramsey\Uuid\Uuid;
+
+$payload[] = [
+    'id' => str_replace('-', '', Uuid::uuid5(
+        Uuid::NAMESPACE_DNS,
+        (string) $product->getUniqueIdentifier()
+    )->toString()),
+];
+```
+
+Most UUID libraries (including `ramsey/uuid`) output the canonical 36-character hyphenated form. Shopware requires the 32-character dashless form, so `str_replace('-', '', ...)` is needed. The same applies to `Uuid::uuid3()`. Plain `sha1()` does not work because it produces 40 hexadecimal characters, which exceeds Shopware's 16-byte (128-bit) ID length.
+
+For imports, pick a stable namespace per entity type (for example, `Uuid::NAMESPACE_DNS` or a project-specific namespace UUID generated once) and use the external system's stable key as the name.
+
+Whichever approach you choose, you can later reuse the same derived ID to push updates to the same record. The same pattern applies to related entities.
 
 ### **Bulk Payloads**
 


### PR DESCRIPTION
 - Expand Primary Keys docs to explain Shopware's 32-char hex ID format (no hyphens)
 - Document md5() as a pragmatic approach and UUID v3/v5 as the RFC 4122 alternative, with an example
 - Add a short Entity IDs note in the request/response structure page with cross-links